### PR TITLE
Add new councillors from backend

### DIFF
--- a/app/controllers/admin/councillors_controller.rb
+++ b/app/controllers/admin/councillors_controller.rb
@@ -6,4 +6,77 @@ class Admin::CouncillorsController < Admin::ApplicationController
   def show
     @councillor = Councillor.find_by(slug: params[:id])
   end
+
+  def new
+    @councillor = Councillor.new
+  end
+
+  def edit
+    @councillor = Councillor.find_by(slug: params[:id])
+  end
+
+  def create
+    @councillor = Councillor.new(councillor_params)
+    ActiveRecord::Base.transaction do
+      if @councillor.save
+        create_membership_if_supplied!(@councillor)
+        redirect_to [:admin, @councillor]
+      else
+        render :new
+      end
+    end
+  end
+
+  def update
+    @councillor = Councillor.find_by(slug: params[:id])
+    if @councillor.update(councillor_params)
+      redirect_to [:admin, @councillor]
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @councillor = Councillor.find_by(slug: params[:id])
+    @councillor.destroy!
+    redirect_to [:admin, :councillors]
+  end
+
+  private
+
+  def councillor_params
+    params.require(:councillor).permit(:given_name, :family_name, :full_name, :gender, :born_on, :portrait)
+  end
+
+  def membership_params
+    params.fetch(:councillor, {}).permit(:local_electoral_area_id, :party_id, :seat_commenced_on)
+  end
+
+  def create_membership_if_supplied!(councillor)
+    lea_id = membership_params[:local_electoral_area_id]
+    party_id = membership_params[:party_id]
+    commenced_on_param = membership_params[:seat_commenced_on]
+
+    return unless lea_id.present?
+
+    council_session = CouncilSession.current || CouncilSession.latest
+    return unless council_session
+
+    commenced_on = if commenced_on_param.present?
+      Date.parse(commenced_on_param) rescue council_session.commenced_on
+    else
+      council_session.commenced_on
+    end
+
+    seat = Seat.create!(
+      council_session: council_session,
+      local_electoral_area_id: lea_id,
+      councillor: councillor,
+      commenced_on: commenced_on
+    )
+
+    if party_id.present?
+      seat.party_affiliations.create!(party_id: party_id)
+    end
+  end
 end

--- a/app/views/admin/councillors/_form.html.haml
+++ b/app/views/admin/councillors/_form.html.haml
@@ -1,0 +1,36 @@
+= form_with model: [:admin, councillor], class: 'admin-form' do |f|
+  = render partial: 'admin/shared/errors', locals: {errors: councillor.errors}
+
+  = f.label :full_name
+  = f.text_field :full_name
+
+  .hint.p.-t5 If you enter full name, given/family names will be derived.
+
+  = f.label :given_name
+  = f.text_field :given_name
+
+  = f.label :family_name
+  = f.text_field :family_name
+
+  = f.label :born_on
+  = f.date_field :born_on
+
+  = f.label :portrait
+  = f.file_field :portrait
+
+  - if councillor.new_record?
+    %hr
+    %h3 Council membership
+    .hint.p.-t5 New councillors must be assigned to the current council with a party and local area.
+
+    = f.label :local_electoral_area_id, 'Local Electoral Area'
+    = f.collection_select :local_electoral_area_id, LocalElectoralArea.by_name, :id, :name, {prompt: 'Select area'}
+
+    = f.label :party_id, 'Party'
+    = f.collection_select :party_id, Party.by_name, :id, :name, {prompt: 'Select party'}
+
+    = f.label :seat_commenced_on, 'Seat start date'
+    = f.date_field :seat_commenced_on, value: Date.current
+
+  .actions
+    = f.submit 'Save', class: 'button'

--- a/app/views/admin/councillors/edit.html.haml
+++ b/app/views/admin/councillors/edit.html.haml
@@ -1,0 +1,10 @@
+%header.view-header
+  .wrapper{role: 'layout'}
+    .breadcrumbs
+      .breadcrumb= link_to 'Councillors', [:admin, :councillors]
+      .breadcrumb= link_to @councillor.full_name, [:admin, @councillor]
+      .breadcrumb= link_to 'Edit', [:edit, :admin, @councillor]
+
+.view-content.-alpha
+  .wrapper{role: 'layout'}
+    = render partial: 'form', locals: { councillor: @councillor }

--- a/app/views/admin/councillors/index.html.haml
+++ b/app/views/admin/councillors/index.html.haml
@@ -1,6 +1,8 @@
 %header.view-header
   .wrapper{role: 'layout'}
     %h1= link_to "Councillors", [:admin, :councillors]
+    .actions
+      = link_to "New councillor", [:new, :admin, :councillor], class: 'button'
 
 %main.view-content{role: 'layout'}
   .wrapper{role: 'layout'}

--- a/app/views/admin/councillors/new.html.haml
+++ b/app/views/admin/councillors/new.html.haml
@@ -1,0 +1,9 @@
+%header.view-header
+  .wrapper{role: 'layout'}
+    .breadcrumbs
+      .breadcrumb= link_to 'Councillors', [:admin, :councillors]
+      .breadcrumb= link_to 'New councillor', [:new, :admin, :councillor]
+
+.view-content.-alpha
+  .wrapper{role: 'layout'}
+    = render partial: 'form', locals: { councillor: @councillor }

--- a/app/views/admin/councillors/show.html.haml
+++ b/app/views/admin/councillors/show.html.haml
@@ -3,6 +3,8 @@
     .breadcrumbs
       .breadcrumb= link_to 'Councillors', [:admin, :councillors]
       .breadcrumb= link_to @councillor.full_name, [:admin, @councillor]
+      .record-actions
+        = link_to 'Edit', [:edit, :admin, @councillor], class: 'button'
 
 .view-content.-alpha
   .wrapper{role: 'layout'}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root to: "dashboard#show"
-    resources :councillors, only: [:index, :show] do
+    resources :councillors do
       resources :media_mentions, only: [:new, :create]
     end
 


### PR DESCRIPTION
Add full CRUD for councillors in the admin interface to allow users to manage council membership changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c83ba5f-577b-4cce-b679-b4f29f6a5df1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0c83ba5f-577b-4cce-b679-b4f29f6a5df1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

