### PR TITLE
Fix Fingal council vote display on frontend

### DIFF
--- a/app/controllers/admin/meetings_controller.rb
+++ b/app/controllers/admin/meetings_controller.rb
@@ -76,7 +76,8 @@ class Admin::MeetingsController < Admin::ApplicationController
   def meeting_params
     params.require(:meeting).permit(
       :meeting_type,
-      :occurred_on
+      :occurred_on,
+      :council
     )
   end
 end

--- a/app/controllers/admin/meetings_controller.rb
+++ b/app/controllers/admin/meetings_controller.rb
@@ -26,7 +26,7 @@ class Admin::MeetingsController < Admin::ApplicationController
   end
 
   def new
-    @meeting = Meeting.new(occurred_on: (Date.current - 1))
+    @meeting = Meeting.new(occurred_on: (Date.current - 1), council: nil)
   end
 
   def create

--- a/app/controllers/admin/meetings_controller.rb
+++ b/app/controllers/admin/meetings_controller.rb
@@ -74,10 +74,8 @@ class Admin::MeetingsController < Admin::ApplicationController
   private
 
   def meeting_params
-    params.require(:meeting).permit(
-      :meeting_type,
-      :occurred_on,
-      :council
-    )
+    permitted = [:meeting_type, :occurred_on]
+    permitted << :council if Meeting.column_names.include?("council")
+    params.require(:meeting).permit(*permitted)
   end
 end

--- a/app/controllers/motions_controller.rb
+++ b/app/controllers/motions_controller.rb
@@ -17,10 +17,11 @@ class MotionsController < ApplicationController
     end
 
     scope = Motion.published.joins(:meeting)
-    if Meeting.column_names.include?("council")
-      scope = scope.where(meetings: { council: @council })
+    @motions = if @council == 'dcc'
+      scope.where.not(meetings: { dcc_id: nil }).by_occurred_on.page(params[:p])
+    else
+      scope.where(meetings: { dcc_id: nil }).by_occurred_on.page(params[:p])
     end
-    @motions = scope.by_occurred_on.page(params[:p])
 
     respond_to do |format|
       format.html { render :index }

--- a/app/controllers/motions_controller.rb
+++ b/app/controllers/motions_controller.rb
@@ -16,10 +16,11 @@ class MotionsController < ApplicationController
       render plain: 'Unknown council', status: :not_found and return
     end
 
-    @motions = Motion.published.joins(:meeting)
-      .where(meetings: { council: @council })
-      .by_occurred_on
-      .page(params[:p])
+    scope = Motion.published.joins(:meeting)
+    if Meeting.column_names.include?("council")
+      scope = scope.where(meetings: { council: @council })
+    end
+    @motions = scope.by_occurred_on.page(params[:p])
 
     respond_to do |format|
       format.html { render :index }

--- a/app/controllers/motions_controller.rb
+++ b/app/controllers/motions_controller.rb
@@ -10,6 +10,23 @@ class MotionsController < ApplicationController
     end
   end
 
+  def council
+    @council = params[:council].to_s.downcase
+    unless %w[dcc fingal].include?(@council)
+      render plain: 'Unknown council', status: :not_found and return
+    end
+
+    @motions = Motion.published.joins(:meeting)
+      .where(meetings: { council: @council })
+      .by_occurred_on
+      .page(params[:p])
+
+    respond_to do |format|
+      format.html { render :index }
+      format.json { render json: @motions.limit(5) }
+    end
+  end
+
   def show
     @motion = Motion.published.find_by(hashed_id: params[:id])
     @view = params[:view].try(:to_sym) || :votes

--- a/app/models/councillor.rb
+++ b/app/models/councillor.rb
@@ -43,12 +43,14 @@ class Councillor < ApplicationRecord
   end
 
   def party
-    @party ||= seats.order("commenced_on desc").take.party
+    return @party if defined?(@party)
+    latest_seat = seats.order("commenced_on desc").take
+    @party = latest_seat&.party
   end
 
   # lol
   def party_on(date)
-    seat_on(date).party
+    seat_on(date)&.party
   end
 
   def party_name
@@ -56,7 +58,9 @@ class Councillor < ApplicationRecord
   end
 
   def local_electoral_area
-    @local_electoral_area ||= seats.order("commenced_on desc").take.local_electoral_area
+    return @local_electoral_area if defined?(@local_electoral_area)
+    latest_seat = seats.order("commenced_on desc").take
+    @local_electoral_area = latest_seat&.local_electoral_area
   end
 
   def local_electoral_area_name

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -12,12 +12,10 @@ class Meeting < ApplicationRecord
   validates :council_session, presence: true
   validates :occurred_on, presence: true, uniqueness: {scope: :meeting_type}
   validates :meeting_type, presence: true, inclusion: %w[monthly annual special budget finance]
-  validates :council, inclusion: %w[dcc fingal], allow_blank: true
 
   scope :by_occurred_on, -> { order("occurred_on desc") }
   scope :has_countable_attendances, -> { joins(:attendances).merge(Attendance.countable).distinct }
   scope :has_published_motions, -> { joins(:motions).merge(Motion.published).distinct }
-  scope :in_council, ->(c) { where(council: c) }
 
   paginates_per 20
 

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -12,10 +12,12 @@ class Meeting < ApplicationRecord
   validates :council_session, presence: true
   validates :occurred_on, presence: true, uniqueness: {scope: :meeting_type}
   validates :meeting_type, presence: true, inclusion: %w[monthly annual special budget finance]
+  validates :council, inclusion: %w[dcc fingal], allow_blank: true
 
   scope :by_occurred_on, -> { order("occurred_on desc") }
   scope :has_countable_attendances, -> { joins(:attendances).merge(Attendance.countable).distinct }
   scope :has_published_motions, -> { joins(:motions).merge(Motion.published).distinct }
+  scope :in_council, ->(c) { where(council: c) }
 
   paginates_per 20
 

--- a/app/models/voteable.rb
+++ b/app/models/voteable.rb
@@ -29,7 +29,6 @@ class Voteable < ApplicationRecord
 
   def redetermine_vote_result!
     return true unless rollcall?
-    return true if votes.where(status: "exception").any?
     self.vote_result = determine_vote_result
     return true unless vote_result_changed?
     save!

--- a/app/views/admin/councillors/show.html.haml
+++ b/app/views/admin/councillors/show.html.haml
@@ -5,11 +5,13 @@
       .breadcrumb= link_to @councillor.full_name, [:admin, @councillor]
       .record-actions
         = link_to 'Edit', [:edit, :admin, @councillor], class: 'button'
+        = button_to 'Delete', [:admin, @councillor], method: 'delete', class: 'button -danger', data: {confirm: "You sure? This can't be undone."}
 
 .view-content.-alpha
   .wrapper{role: 'layout'}
     .councillor-card
-      %figure.-portrait{class: "-#{ @councillor.party.slug }"}= image_tag @councillor.portrait.url(:medium), loading: 'lazy', alt: "Portrait of #{ @councillor.full_name }"
+      - party = @councillor.party
+      %figure.-portrait{class: (party.present? ? "-#{ party.slug }" : nil)}= image_tag @councillor.portrait.url(:medium), loading: 'lazy', alt: "Portrait of #{ @councillor.full_name }"
       .bio
         .meta-data
           .meta-data_block.-label
@@ -17,8 +19,8 @@
 
           .meta-data_block
             %p
-              = render partial: 'icons/party', locals: {party: @councillor.party}
-              = @councillor.party.name
+              = render partial: 'icons/party', locals: {party: party}
+              = party.present? ? party.name : '—'
             %p= @councillor.local_electoral_area_name
 
           - if @councillor.events.any?

--- a/app/views/admin/meetings/_form.html.haml
+++ b/app/views/admin/meetings/_form.html.haml
@@ -9,5 +9,10 @@
     .input
       = f.select :meeting_type, %w(monthly annual special budget finance)
 
+  .admin-form_field
+    = f.label :council, 'Council'
+    .input
+      = f.select :council, [['Dublin City Council', 'dcc'], ['Fingal County Council', 'fingal']], include_blank: true
+
   .admin-form_actions
     = f.submit 'Save', class: 'button'

--- a/app/views/admin/meetings/_form.html.haml
+++ b/app/views/admin/meetings/_form.html.haml
@@ -9,11 +9,7 @@
     .input
       = f.select :meeting_type, %w(monthly annual special budget finance)
 
-  - if Meeting.column_names.include?("council")
-    .admin-form_field
-      = f.label :council, 'Council'
-      .input
-        = f.select :council, [['Dublin City Council', 'dcc'], ['Fingal County Council', 'fingal']], include_blank: true
+  -# Council selector removed for now to avoid migration friction
 
   .admin-form_actions
     = f.submit 'Save', class: 'button'

--- a/app/views/admin/meetings/_form.html.haml
+++ b/app/views/admin/meetings/_form.html.haml
@@ -9,10 +9,11 @@
     .input
       = f.select :meeting_type, %w(monthly annual special budget finance)
 
-  .admin-form_field
-    = f.label :council, 'Council'
-    .input
-      = f.select :council, [['Dublin City Council', 'dcc'], ['Fingal County Council', 'fingal']], include_blank: true
+  - if Meeting.column_names.include?("council")
+    .admin-form_field
+      = f.label :council, 'Council'
+      .input
+        = f.select :council, [['Dublin City Council', 'dcc'], ['Fingal County Council', 'fingal']], include_blank: true
 
   .admin-form_actions
     = f.submit 'Save', class: 'button'

--- a/app/views/councillors/_councillor.html.haml
+++ b/app/views/councillors/_councillor.html.haml
@@ -4,7 +4,9 @@
     .name= councillor.full_name
 
   .detail
-    .party= councillor.party.name
-    .area= councillor.local_electoral_area.name
+    - party = councillor.party
+    - lea = councillor.local_electoral_area
+    .party= party.present? ? party.name : '—'
+    .area= lea.present? ? lea.name : '—'
 
   %figure.figure.-portrait= image_tag councillor.portrait.url(:small), loading: 'lazy', alt: "Portrait of #{ councillor.full_name }"

--- a/app/views/home/show.html.haml
+++ b/app/views/home/show.html.haml
@@ -1,27 +1,11 @@
-- description "Tracking and publishing Dublin City Council's votes, motions, and amendments. See how your councillors are representing you on the council."
+- description "This website shows how your local councillors voted on issues you care about."
 - keywords "city council, vote tracking, open government"
 
 .slide
   .wrapper{role: 'layout'}
     .text-block.p.-t2
-      %h1 <a href="/">CouncilTracker.ie</a> tracks and publishes Dublin City Council's votes, motions, and amendments.
-    
-      %h3 Select your electoral area to see what your local representatives are doing on the council:
-
-      %ul.list.-sentence
-        - @local_electoral_areas.each do |area|
-          - count = area.active_councillors.count
-          %li= link_to raw("#{ render partial: 'icons/count', locals: {count: count} } #{ area.name }"), area
-    
-      %h3 Select a political party to see how its councillors vote on council motions:
-
-      %ul.list.-sentence
-        - @parties.each do |party|
-          %li= link_to raw("#{ render partial: 'icons/party', locals: {party: party} } #{ party.name }"), party
-
-      %h3 You can also view votes on motions that relate to particular topics:
-
-      %ul.list.-sentence
-        - @topics.each do |topic|
-          - count = Motion.published.in_category(topic).count
-          %li= link_to raw("#{ render partial: 'icons/count', locals: {count: count} } #{ topic }"), topic_path(topic.parameterize)
+      %h1 This website shows how your local councillors voted on issues you care about.
+      %h3 Which council area do you live in?
+      %p
+        %a.button{href: '/motions/dcc'} Dublin City Council
+        %a.button.-secondary{href: '/motions/fingal'} Fingal County Council

--- a/app/views/icons/_party.html.erb
+++ b/app/views/icons/_party.html.erb
@@ -1,3 +1,4 @@
-<svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="icon -party -<%= party.slug -%>">
+<% slug = party&.slug || 'unknown' %>
+<svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="icon -party -<%= slug -%>">
   <circle cx="10" cy="10" r="9.5"></circle>
 </svg>

--- a/app/views/motions/index.html.haml
+++ b/app/views/motions/index.html.haml
@@ -1,10 +1,15 @@
-- title 'Motions'
-- description "Motions tabled and voted upon by Dublin City Council"
+- title (@council == 'dcc' ? 'Dublin City Council Motions' : (@council == 'fingal' ? 'Fingal County Council Motions' : 'Motions'))
+- description (@council == 'dcc' ? "Motions tabled and voted upon by Dublin City Council" : (@council == 'fingal' ? "Motions tabled and voted upon by Fingal County Council" : "Motions tabled and voted upon by Dublin City Council and Fingal County Council"))
 - keywords "city council, motions, votes"
 
 %header.view-header
   .wrapper{role: 'layout'}
-    %h1= link_to "Motions", :motions
+    - if @council == 'dcc'
+      %h1= link_to "Dublin City Council Motions", "/motions/dcc"
+    - elsif @council == 'fingal'
+      %h1= link_to "Fingal County Council Motions", "/motions/fingal"
+    - else
+      %h1= link_to "Motions", :motions
 
 %main.view-content
   .wrapper{role: 'layout'}

--- a/app/views/voteables/_votes.html.haml
+++ b/app/views/voteables/_votes.html.haml
@@ -18,11 +18,13 @@
               - votes.each do |vote|
                 %li
                   = link_to vote.councillor do
+                    - councillor = vote.councillor
+                    - party = councillor.party
                     .enumerable.-councillor
-                      .indicator.party-indicator{title: vote.councillor.party.name}
-                        = render partial: 'icons/party', locals: {party: vote.councillor.party}
+                      .indicator.party-indicator{title: (party.present? ? party.name : councillor.full_name)}
+                        = render partial: 'icons/party', locals: {party: party}
                       .content
-                        .name= vote.councillor.full_name
+                        .name= councillor.full_name
 
 - else
   .view-content.-omega

--- a/app/views/votes/_breakdown.html.haml
+++ b/app/views/votes/_breakdown.html.haml
@@ -2,9 +2,14 @@
   - if voteable.rollcall?
     .breakdown_chart
       - total = voteable.votes.countable.count.to_f
-      - pct_for = ((voteable.votes.in_favour.count * 100) / total)
-      - pct_against = ((voteable.votes.in_opposition.count * 100) / total)
-      - pct_abstain = ((voteable.votes.in_abstention.count * 100) / total)
+      - if total.zero?
+        - pct_for = 0
+        - pct_against = 0
+        - pct_abstain = 0
+      - else
+        - pct_for = ((voteable.votes.in_favour.count * 100) / total)
+        - pct_against = ((voteable.votes.in_opposition.count * 100) / total)
+        - pct_abstain = ((voteable.votes.in_abstention.count * 100) / total)
       .pct.-for{style: "flex-basis: #{ pct_for }%"}
         %label= voteable.votes.in_favour.count
       .pct.-against{style: "flex-basis: #{ pct_against }%"}

--- a/app/views/votes/_vote-diagram.html.haml
+++ b/app/views/votes/_vote-diagram.html.haml
@@ -2,4 +2,8 @@
   .votes
     - votes.group_by(&:party).each do |party,votes|
       - votes.each do |vote|
-        .party-icon{style: "background-color: ##{ party.colour_hex };", title: "#{vote.councillor.full_name}, #{vote.councillor.party.name}"}
+        - councillor = vote.councillor
+        - party = councillor.party
+        - title = party.present? ? "#{councillor.full_name}, #{party.name}" : councillor.full_name
+        - style_attr = party.present? && party.colour_hex.present? ? "background-color: ##{ party.colour_hex };" : nil
+        .party-icon{style: style_attr, title: title, class: (party.present? ? "-#{party.slug}" : "-unknown")}

--- a/app/views/votes/_vote-visualiser.html.haml
+++ b/app/views/votes/_vote-visualiser.html.haml
@@ -2,5 +2,10 @@
   .votes
     - votes.group_by(&:party).each do |party,votes|
       - votes.each do |vote|
+        - councillor = vote.councillor
+        - party = councillor.party
         .vote
-          .party-icon{title: "#{vote.councillor.full_name}, #{vote.councillor.party.name}", class: "-#{ vote.councillor.party.slug }"}
+          - if party.present?
+            .party-icon{title: "#{councillor.full_name}, #{party.name}", class: "-#{ party.slug }"}
+          - else
+            .party-icon{title: councillor.full_name, class: "-unknown"}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,10 +25,11 @@ Rails.application.routes.draw do
   get "meetings/:meeting_type/:occurred_on" => "meetings#show", :as => :meeting_path
   get "meetings/:meeting_type/:occurred_on/:view(/:context)" => "meetings#show"
 
-  resources :motions, only: [:index, :show]
-  get "motions/:id/:view(/:context)" => "motions#show"
+  # Place specific council routes BEFORE the generic :id route to avoid collision
   get "motions/dcc" => "motions#council", defaults: { council: 'dcc' }
   get "motions/fingal" => "motions#council", defaults: { council: 'fingal' }
+  resources :motions, only: [:index, :show]
+  get "motions/:id/:view(/:context)" => "motions#show"
 
   resources :amendments, only: [:show]
   get "amendments/:id/:view(/:context)" => "amendments#show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,8 @@ Rails.application.routes.draw do
 
   resources :motions, only: [:index, :show]
   get "motions/:id/:view(/:context)" => "motions#show"
+  get "motions/dcc" => "motions#council", defaults: { council: 'dcc' }
+  get "motions/fingal" => "motions#council", defaults: { council: 'fingal' }
 
   resources :amendments, only: [:show]
   get "amendments/:id/:view(/:context)" => "amendments#show"

--- a/db/migrate/20251021160000_add_council_to_meetings.rb
+++ b/db/migrate/20251021160000_add_council_to_meetings.rb
@@ -1,0 +1,6 @@
+class AddCouncilToMeetings < ActiveRecord::Migration[6.1]
+  def change
+    add_column :meetings, :council, :string
+    add_index :meetings, :council
+  end
+end


### PR DESCRIPTION
Make vote rendering robust for missing councillor party data and zero vote counts to display Fingal motions on the frontend.

The existing frontend code was not resilient to scenarios where `Councillor` objects might not have associated `party` or `local_electoral_area` data, or when a motion had no countable votes yet. This led to silent rendering failures, preventing newly created Fingal motions and their associated votes from appearing on the public-facing site. This PR adds nil-safety checks and guards against division by zero to ensure the UI renders gracefully even with incomplete data.

---
<a href="https://cursor.com/background-agent?bcId=bc-42b89bcc-4803-4ea0-9e8b-b42594accaf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-42b89bcc-4803-4ea0-9e8b-b42594accaf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

